### PR TITLE
Feat : Signin & Signup & Result Page

### DIFF
--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+
+interface CButtom {
+  text: string;
+  fullWidth: boolean;
+  variant?: 'text' | 'outlined' | 'contained';
+  sx: {
+    mt: number;
+    mb: number;
+  };
+}
+
+function CButton({ text, fullWidth, variant, sx }: CButtom) {
+  return (
+    <Button type='submit' fullWidth={fullWidth} variant={variant} sx={sx}>
+      {text}
+    </Button>
+  );
+}
+
+export default CButton;

--- a/components/common/Card/index.tsx
+++ b/components/common/Card/index.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+interface BasicCardProps {
+  title: string;
+  subTitle?: string;
+  content: string;
+}
+
+export default function BasicCard({ title, subTitle, content }: BasicCardProps) {
+  return (
+    <Card sx={{ minWidth: 275 }}>
+      <CardContent>
+        <Typography sx={{ fontSize: 14 }} color='text.secondary' gutterBottom>
+          {subTitle}
+        </Typography>
+        <Typography variant='h5' component='div'>
+          {title}
+        </Typography>
+        <Typography variant='body2'>{content}</Typography>
+      </CardContent>
+      <CardActions>
+        <Button size='small'>Learn More</Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/components/common/Copyright/index.tsx
+++ b/components/common/Copyright/index.tsx
@@ -1,0 +1,21 @@
+import { Typography } from '@mui/material';
+import Link from 'next/link';
+
+type CopyrightProps = {
+  [key: string]: number;
+};
+
+function Copyright({ mt, mb }: CopyrightProps) {
+  return (
+    <Typography variant='body2' color='text.secondary' align='center' mt={mt} mb={mb}>
+      {'Copyright © '}
+      <Link color='inherit' href='https://mui.com/'>
+        HayeongShin
+      </Link>{' '}
+      {new Date().getFullYear()}
+      {'.'}
+    </Typography>
+  );
+}
+
+export default Copyright;

--- a/components/login/SubmitForm/index.tsx
+++ b/components/login/SubmitForm/index.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import CButton from '@/components/common/Button';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Copyright from '@/components/common/Copyright';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { Avatar, Container, CssBaseline, Link, ThemeProvider, Typography, createTheme } from '@mui/material';
+
+const defaultTheme = createTheme();
+
+interface SubmitFormProps {
+  submitFormTitle: string;
+  fields: {
+    name: string;
+    label: string;
+    type?: string;
+    required?: boolean;
+    autoComplete?: string;
+  }[];
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  buttonText: string;
+  checkboxLabel?: string;
+  onCheckboxChange?: (checked: boolean) => void;
+}
+
+function SubmitForm({
+  submitFormTitle,
+  fields,
+  onSubmit,
+  buttonText,
+  checkboxLabel,
+  onCheckboxChange,
+}: SubmitFormProps) {
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      <Container component='main' maxWidth='xs'>
+        <CssBaseline />
+        <Box
+          sx={{
+            marginTop: 8,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component='h1' variant='h5'>
+            {submitFormTitle}
+          </Typography>
+          <Box component='form' noValidate onSubmit={onSubmit} sx={{ mt: 8 }}>
+            <Grid container spacing={2}>
+              {fields.map(field => (
+                <Grid item xs={12} key={field.name}>
+                  <TextField
+                    required={field.required}
+                    fullWidth
+                    id={field.name}
+                    label={field.label}
+                    name={field.name}
+                    type={field.type || 'text'}
+                    autoComplete={field.autoComplete}
+                  />
+                </Grid>
+              ))}
+              {checkboxLabel && (
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={<Checkbox color='primary' onChange={e => onCheckboxChange?.(e.target.checked)} />}
+                    label={checkboxLabel}
+                  />
+                </Grid>
+              )}
+            </Grid>
+            <CButton fullWidth variant='contained' sx={{ mt: 3, mb: 2 }} text={buttonText} />
+            {submitFormTitle === 'Sign in' ? (
+              <Grid container>
+                <Grid item xs>
+                  <Link href='#' variant='body2'>
+                    Forgot password?
+                  </Link>
+                </Grid>
+                <Grid item>
+                  <Link href='/login/signup' variant='body2'>
+                    {"Don't have an account? Sign Up"}
+                  </Link>
+                </Grid>
+              </Grid>
+            ) : (
+              <Grid container justifyContent='flex-end'>
+                <Grid item>
+                  <Link href='/login/signin' variant='body2'>
+                    Already have an account? Sign in
+                  </Link>
+                </Grid>
+              </Grid>
+            )}
+          </Box>
+        </Box>
+        <Copyright mt={5} />
+      </Container>
+    </ThemeProvider>
+  );
+}
+
+export default SubmitForm;

--- a/components/result/Main/index.tsx
+++ b/components/result/Main/index.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { Box, Container, Grid, ThemeProvider, Typography, createTheme } from '@mui/material';
+import BasicCard from '@/components/common/Card';
+import Link from 'next/link';
+
+const defaultTheme = createTheme();
+
+function Main() {
+  const [resultData, setResultData] = useState<any>([{}]);
+
+  useEffect(() => {
+    fetch('https://64f732e69d775408495348ae.mockapi.io/api/v1/authmock')
+      .then(response => response.json())
+      .then(response => setResultData(response));
+  }, []);
+
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      <Typography
+        component='h1'
+        variant='h5'
+        sx={{
+          m: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        Result Page
+        <Link href='/login/signin' style={{ color: 'blue', textDecoration: 'underline', marginTop: '8px' }}>
+          logout
+        </Link>
+      </Typography>
+      <Container component='main' maxWidth='md'>
+        <Grid container spacing={5}>
+          {resultData.map((item: any) => (
+            <Grid item xs={4} key={uuidv4()}>
+              <BasicCard title={item.id} content={item.name} />
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </ThemeProvider>
+  );
+}
+
+export default Main;

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/login/signin',
+        permanent: false,
+      },
+    ];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "20.6.3",
         "@types/react": "18.2.22",
         "@types/react-dom": "18.2.7",
+        "@types/uuid": "^9.0.4",
         "eslint": "8.49.0",
         "eslint-config-next": "13.5.2",
         "eslint-plugin-prettier": "^5.0.0",
@@ -22,7 +23,8 @@
         "prettier": "^3.0.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "typescript": "5.2.2"
+        "typescript": "5.2.2",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1012,6 +1014,11 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.7.2",
@@ -4528,6 +4535,18 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -5309,6 +5328,11 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+    },
+    "@types/uuid": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA=="
     },
     "@typescript-eslint/parser": {
       "version": "6.7.2",
@@ -7720,6 +7744,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "20.6.3",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
+    "@types/uuid": "^9.0.4",
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.2",
     "eslint-plugin-prettier": "^5.0.0",
@@ -23,6 +24,7 @@
     "prettier": "^3.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "uuid": "^9.0.1"
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,13 +4,7 @@ import { NextPage } from 'next/types';
 const Home: NextPage = () => {
   return (
     <div>
-      <main>
-        <Stack spacing={2} direction='row'>
-          <Button variant='text'>Text</Button>
-          <Button variant='contained'>Contained</Button>
-          <Button variant='outlined'>Outlined</Button>
-        </Stack>
-      </main>
+      <main></main>
     </div>
   );
 };

--- a/pages/login/signin/index.tsx
+++ b/pages/login/signin/index.tsx
@@ -1,0 +1,33 @@
+import SubmitForm from '@/components/login/SubmitForm';
+import { useRouter } from 'next/router';
+
+function SignIn() {
+  const fields = [
+    { name: 'email', label: 'Email Address', type: 'email', required: true, autoComplete: 'email' },
+    { name: 'password', label: 'Password', type: 'password', required: true, autoComplete: 'current-password' },
+  ];
+
+  const router = useRouter();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+    router.replace('/result');
+  };
+
+  return (
+    <SubmitForm
+      submitFormTitle='Sign in'
+      fields={fields}
+      onSubmit={handleSubmit}
+      buttonText='Sign In'
+      checkboxLabel='Remember me'
+    />
+  );
+}
+
+export default SignIn;

--- a/pages/login/signup/index.tsx
+++ b/pages/login/signup/index.tsx
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import SubmitForm from '@/components/login/SubmitForm';
+
+function SignUp() {
+  const fields = [
+    { name: 'firstName', label: 'First Name', required: true, autoComplete: 'given-name' },
+    { name: 'lastName', label: 'Last Name', required: true, autoComplete: 'family-name' },
+    { name: 'email', label: 'Email Address', type: 'email', required: true, autoComplete: 'email' },
+    { name: 'password', label: 'Password', type: 'password', required: true, autoComplete: 'new-password' },
+  ];
+
+  const router = useRouter();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      firstName: data.get('firstName'),
+      lastName: data.get('lastName'),
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+    router.replace('/login/signin');
+  };
+
+  return <SubmitForm submitFormTitle='Sign up' fields={fields} onSubmit={handleSubmit} buttonText='Sign Up' />;
+}
+
+export default SignUp;

--- a/pages/result/index.tsx
+++ b/pages/result/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import dynamic from 'next/dynamic';
+
+const Main = dynamic(() => import('@/components/result/Main'), { ssr: false });
+
+function Result() {
+  return (
+    <>
+      <Main />
+    </>
+  );
+}
+
+export default Result;


### PR DESCRIPTION
### 📌 페이지 1 아이디, 비밀번호 입력 및 츨력 페이지
- mui 활용해 폼 ui 구현
- SubmitForm 공통 컴포넌트 제작해 fields에 따라 input 렌더링

### 📌 페이지 2 Mock API를 이용해 화면에 호출 결과를 출력하는 페이지
- fetch를 사용해 Mock API 호출
- 출력 결과 아이디, 이름 형태의 카드 리스트로 렌더링